### PR TITLE
Chaning the target framework to netstardard 2.0

### DIFF
--- a/src/Ardalis.ListStartupServices/Ardalis.ListStartupServices.csproj
+++ b/src/Ardalis.ListStartupServices/Ardalis.ListStartupServices.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+	<TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Ardalis.ListStartupServices</PackageId>
     <Title>Ardalis.ListStartupServices</Title>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -13,14 +13,16 @@
     <RepositoryUrl>https://github.com/ardalis/AspNetCoreStartupServices</RepositoryUrl>
     <PackageTags>asp.net core, diagnostic, services, ServiceCollection</PackageTags>
     <PackageReleaseNotes>Fixed a bug with pass-through of middleware</PackageReleaseNotes>
-    <Version>1.1.3</Version>
+    <Version>1.1.4</Version>
     <PackageIconUrl>https://user-images.githubusercontent.com/782127/33497760-facf6550-d69c-11e7-94e4-b3856da259a9.png</PackageIconUrl>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RootNamespace>Ardalis.ListStartupServices</RootNamespace>
   </PropertyGroup>
-  
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore" Version="1.1.0"  />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/WebDemo/AspNetCoreStartupServices.csproj
+++ b/src/WebDemo/AspNetCoreStartupServices.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.0" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Ardalis.ListStartupServices\Ardalis.ListStartupServices.csproj" />

--- a/src/WebDemo/Startup.cs
+++ b/src/WebDemo/Startup.cs
@@ -4,6 +4,8 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
 using System.Collections.Generic;
 
 namespace WebApplication
@@ -29,7 +31,7 @@ namespace WebApplication
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             if (env.IsDevelopment())
             {

--- a/test/Ardalis.ListStartupServices.Tests/Ardalis.ListStartupServices.Tests.csproj
+++ b/test/Ardalis.ListStartupServices.Tests/Ardalis.ListStartupServices.Tests.csproj
@@ -1,20 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+	<TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Moq" Version="4.10.0" />
-    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+  	<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.26" />
+  	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+  	<PackageReference Include="Moq" Version="4.10.0" />
+  	<PackageReference Include="NETStandard.Library" Version="2.0.3" />
+  	<PackageReference Include="xunit" Version="2.4.0" />
+  	<PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I'm currently using this project in a few of my applications.  Because this targets an older version of net core, I'm getting a ton of vulnerabilities in my static analysis tool.  I've updated the target to netstandard so it'll work for my net 3.1 and net 6 projects and resolve the vulnerabilities I'm seeing. 